### PR TITLE
fix #30: add api_key_header option to config

### DIFF
--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -23,6 +23,7 @@ ATTR_ICON = "Icon"
 
 CONF_API_KEY = "api_key"
 CONF_X_API_KEY = "x_api_key"
+CONF_API_KEY_HEADER_NAME = "api_key_header"
 CONF_STOP_ID = "stopid"
 CONF_ROUTE = "route"
 CONF_DIRECTION_ID = "directionid"
@@ -273,13 +274,14 @@ class PublicTransportData(object):
         route_delimiter=None,
         api_key=None,
         x_api_key=None,
+        api_key_header="Authorization",
     ):
         """Initialize the info object."""
         self._trip_update_url = trip_update_url
         self._vehicle_position_url = vehicle_position_url
         self._route_delimiter = route_delimiter
         if api_key is not None:
-            self._headers = {"Authorization": api_key}
+            self._headers = {api_key_header: api_key}
         elif x_api_key is not None:
             self._headers = {"x-api-key": x_api_key}
         else:

--- a/custom_components/gtfs_rt/test.py
+++ b/custom_components/gtfs_rt/test.py
@@ -14,6 +14,7 @@ import yaml
 from schema import Optional, Schema, SchemaError
 from sensor import (
     CONF_API_KEY,
+    CONF_API_KEY_HEADER_NAME,
     CONF_DEPARTURES,
     CONF_DIRECTION_ID,
     CONF_ICON,
@@ -41,6 +42,7 @@ PLATFORM_SCHEMA = Schema(
         CONF_TRIP_UPDATE_URL: str,
         Optional(CONF_API_KEY): str,
         Optional(CONF_X_API_KEY): str,
+        Optional(CONF_API_KEY_HEADER_NAME): str,
         Optional(CONF_VEHICLE_POSITION_URL): str,
         Optional(CONF_ROUTE_DELIMITER): str,
         CONF_DEPARTURES: [
@@ -102,6 +104,7 @@ if __name__ == "__main__":
             configuration.get(CONF_ROUTE_DELIMITER),
             configuration.get(CONF_API_KEY, None),
             configuration.get(CONF_X_API_KEY, None),
+            configuration.get(CONF_API_KEY_HEADER_NAME, None),
         )
 
         sensors = []


### PR DESCRIPTION
This PR fixes #30 by adding a new optional config parameter `api_key_header`, which allows the user to easily override the default `Authorization` header name with the one expected by the API. If none is provided, default to the existing behavior and use `Authorization` as the header name.

In the case of WMATA as described in the issue, this would look like:
```yaml
  - platform: gtfs_rt
    trip_update_url: "https://api.wmata.com/gtfs/bus-gtfsrt-tripupdates.pb"
    vehicle_position_url: "https://api.wmata.com/gtfs/bus-gtfsrt-vehiclepositions.pb"
    api_key: <api key here>
    api_key_header: "api_key"
    # departures here
```