### PR TITLE
Added support for  OCP-APIM Subscription Key needed for Victorian PTV (and others) GTFS-RT datasource

### DIFF
--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -23,6 +23,7 @@ ATTR_ICON = "Icon"
 
 CONF_API_KEY = "api_key"
 CONF_X_API_KEY = "x_api_key"
+CONF_OCP_APIM_SUBSCRIPTION_KEY= 'ocp_apim_subscription_key'
 CONF_STOP_ID = "stopid"
 CONF_ROUTE = "route"
 CONF_DIRECTION_ID = "directionid"
@@ -45,6 +46,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
         vol.Optional(CONF_API_KEY): cv.string,
         vol.Optional(CONF_X_API_KEY): cv.string,
+        vol.Optional(CONF_OCP_APIM_SUBSCRIPTION_KEY): cv.string,
         vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
         vol.Optional(CONF_ROUTE_DELIMITER): cv.string,
         vol.Optional(CONF_DEPARTURES): [
@@ -101,6 +103,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_ROUTE_DELIMITER),
         config.get(CONF_API_KEY),
         config.get(CONF_X_API_KEY),
+        config.get(CONF_OCP_APIM_SUBSCRIPTION_KEY),
     )
     sensors = []
     for departure in config.get(CONF_DEPARTURES):
@@ -273,6 +276,8 @@ class PublicTransportData(object):
         route_delimiter=None,
         api_key=None,
         x_api_key=None,
+        ocp_apim_subscription_key=None,
+
     ):
         """Initialize the info object."""
         self._trip_update_url = trip_update_url
@@ -282,6 +287,8 @@ class PublicTransportData(object):
             self._headers = {"Authorization": api_key}
         elif x_api_key is not None:
             self._headers = {"x-api-key": x_api_key}
+        elif ocp_apim_subscription_key is not None:
+            self._headers = {"Ocp-Apim-Subscription-Key": ocp_apim_subscription_key}
         else:
             self._headers = None
         self.info = {}

--- a/custom_components/gtfs_rt/test.py
+++ b/custom_components/gtfs_rt/test.py
@@ -24,6 +24,7 @@ from sensor import (
     CONF_TRIP_UPDATE_URL,
     CONF_VEHICLE_POSITION_URL,
     CONF_X_API_KEY,
+    CONF_OCP_APIM_SUBSCRIPTION_KEY,
     DEFAULT_DIRECTION,
     DEFAULT_ICON,
     DEFAULT_SERVICE,
@@ -41,6 +42,7 @@ PLATFORM_SCHEMA = Schema(
         CONF_TRIP_UPDATE_URL: str,
         Optional(CONF_API_KEY): str,
         Optional(CONF_X_API_KEY): str,
+        Optional(CONF_OCP_APIM_SUBSCRIPTION_KEY): str,
         Optional(CONF_VEHICLE_POSITION_URL): str,
         Optional(CONF_ROUTE_DELIMITER): str,
         CONF_DEPARTURES: [
@@ -102,6 +104,7 @@ if __name__ == "__main__":
             configuration.get(CONF_ROUTE_DELIMITER),
             configuration.get(CONF_API_KEY, None),
             configuration.get(CONF_X_API_KEY, None),
+            configuration.get(CONF_OCP_APIM_SUBSCRIPTION_KEY, None),
         )
 
         sensors = []

--- a/custom_components/gtfs_rt/test_translink.yaml
+++ b/custom_components/gtfs_rt/test_translink.yaml
@@ -1,6 +1,6 @@
 trip_update_url: 'https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/tripupdates'
 vehicle_position_url: 'https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/vehicleposition'
-ocp_apim_subscription_key: 'd317a7058099484c8a76748707d2ca28'
+ocp_apim_subscription_key: 'xxx'
 route_delimiter: '-'
 departures:
 - name: 'Home'

--- a/custom_components/gtfs_rt/test_translink.yaml
+++ b/custom_components/gtfs_rt/test_translink.yaml
@@ -1,7 +1,12 @@
-trip_update_url: 'https://gtfsrt.api.translink.com.au/api/realtime/SEQ/TripUpdates'
-vehicle_position_url: 'https://gtfsrt.api.translink.com.au/api/realtime/SEQ/VehiclePositions'
+trip_update_url: 'https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/tripupdates'
+vehicle_position_url: 'https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/vehicleposition'
+ocp_apim_subscription_key: 'd317a7058099484c8a76748707d2ca28'
 route_delimiter: '-'
 departures:
-- name: 'Ferny Grove Train'
-  route: BNFG
-  stopid: '600195'
+- name: 'Home'
+  route: "3-70-mjp-1"
+  stopid: "19431"
+  directionid: "0"
+  icon: mdi:tram
+  service_type: Tram
+


### PR DESCRIPTION
This datasource
 https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/tripupdates 
and
 https://data-exchange-api.vicroads.vic.gov.au/opendata/gtfsr/v1/tram/vehicleposition 
Need Ocp-Apim-Subscription-Key in the header. This PR adds support and it seems to work.
That said, I still cannot get sensible answers out of the API but I'll open an issue for that